### PR TITLE
add --allow-no-migration to default symfony_doctrine_migrations_flags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ set :symfony_doctrine_cache_clear_query_flags, '--env=prod'
 set :symfony_doctrine_cache_clear_query_roles, :db
 set :symfony_doctrine_cache_clear_result_flags, '--env=prod'
 set :symfony_doctrine_cache_clear_result_roles, :db
-set :symfony_doctrine_migrations_flags, '--no-interaction'
+set :symfony_doctrine_migrations_flags, '--no-interaction --allow-no-migration'
 set :symfony_doctrine_migrations_roles, :db
 ```
 

--- a/lib/capistrano/tasks/symfony-doctrine.rake
+++ b/lib/capistrano/tasks/symfony-doctrine.rake
@@ -31,7 +31,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :symfony_doctrine_migrations_flags, '--no-interaction --no-debug'
+    set :symfony_doctrine_migrations_flags, '--allow-no-migration --no-interaction --no-debug'
     set :symfony_doctrine_migrations_roles, :db
     set :symfony_doctrine_migrations_servers, -> { release_roles(fetch(:symfony_doctrine_migrations_roles)) }
     set :symfony_doctrine_cache_clear_metadata_flags, '--no-debug'


### PR DESCRIPTION
add --allow-no-migration to default symfony_doctrine_migrations_flags option